### PR TITLE
fix(http): allow self-signed HTTPS upstream without listener TLS

### DIFF
--- a/internal/proxy/base/proxy.go
+++ b/internal/proxy/base/proxy.go
@@ -122,8 +122,10 @@ func NewBaseProxy(
 
 		//nolint: gosec // ignore tls min version
 		base.TLSConfig = &tls.Config{
-			Certificates:       certs,
-			InsecureSkipVerify: true, // for selfsigned tls client certs
+			Certificates: certs,
+			// We are acting as a proxy to potentially self-signed HTTPS upstreams.
+			// This disables upstream certificate verification.
+			InsecureSkipVerify: true, //nolint:gosec
 		}
 	}
 

--- a/internal/proxy/http/proxy.go
+++ b/internal/proxy/http/proxy.go
@@ -94,6 +94,14 @@ func NewProxy(
 			ForceAttemptHTTP2: true,
 		}
 		p.server.TLSConfig = p.TLSConfig
+	} else if p.TargetURL.Scheme == "https" {
+		// Allow proxying to self-signed HTTPS upstreams even when
+		// this proxy itself is not serving TLS.
+		//nolint:gosec // explicit insecure option for self-signed upstreams
+		p.client.Transport = &http.Transport{
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			ForceAttemptHTTP2: true,
+		}
 	}
 
 	// TODO: Remove next when HTTP2 will support Drop


### PR DESCRIPTION
## Problem
Self-signed HTTPS upstreams fail when the `http` proxy listens on plain HTTP (no `tls:`), because the upstream client uses the default transport and performs certificate verification.
## Fix
- If `target` scheme is `https` and `tls:` is not configured, set `p.client.Transport` with `InsecureSkipVerify: true`.
- Keep existing behavior when `tls:` is configured.
## Changes
- internal/proxy/http/proxy.go
- internal/proxy/base/proxy.go (lint/comment only)